### PR TITLE
gapps fixed

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -89,10 +89,10 @@
 
 <!-- BEGIN OPENGAPPS-X86 -->
 
-  <project path="vendor/google/build" name="aosp_build" revision="master" remote="opengapps" />
-  <project path="vendor/opengapps/sources/all" name="all" clone-depth="1" revision="master" remote="opengapps" />
-  <project path="vendor/opengapps/sources/x86" name="x86" clone-depth="1" revision="master" remote="opengapps" />
-  <project path="vendor/opengapps/sources/x86_64" name="x86_64" clone-depth="1" revision="master" remote="opengapps" />
+  <project path="vendor/google/build" name="electrikjesus/aosp_build" revision="master" remote="github" />
+  <project path="vendor/opengapps/sources/all" name="electrikjesus/all" clone-depth="1" revision="master" remote="github" />
+  <project path="vendor/opengapps/sources/x86" name="electrikjesus/x86" clone-depth="1" revision="master" remote="github" />
+  <project path="vendor/opengapps/sources/x86_64" name="electrikjesus/x86_64" clone-depth="1" revision="master" remote="github" />
 
 <!-- END OPENGAPPS-X86 -->
 


### PR DESCRIPTION
Gapps fixed, without this change would bring an error when building
vendor/google/build/opengapps-packages.mk:1: vendor/opengapps/build/core/definitions.mk: No such file or directory