### PR TITLE
android-x86.xml: Fix build errors

### DIFF
--- a/android-x86.xml
+++ b/android-x86.xml
@@ -207,7 +207,7 @@
 	
 	<!-- Bliss Items -->
 	<project path="prebuilts/tools-bliss" name="platform_prebuilts_tools-bliss" remote="BlissRoms" revision="q"/>
-	<project path="packages/apps/ThemePicker" name="platform_packages_apps_ThemePicker" remote="BlissRoms" revision="q" /> 
+	<project path="packages/apps/ThemePicker" name="platform_packages_apps_ThemePicker" remote="BlissRoms" revision="155d480a2566c3f48a74c735bcb1652b61e92cf0" /> 
 	<project path="packages/apps/SettingsIntelligence" name="platform_packages_apps_SettingsIntelligence" remote="BlissRoms" revision="p9.0" />
 	
 	<!-- Extra features from Spurv-->
@@ -266,7 +266,7 @@
 	<project path="hardware/x86power" name="hardware-x86power" remote="BR-x86" revision="q-x86-12.1" />
 	<!-- <project path="hardware/x86power" name="platform/hardware/x86power" remote="x86" revision="q-x86" groups="notdefault" /> -->
 	<project path="packages/apps/Camera2" name="platform/packages/apps/Camera2" remote="x86" revision="q-x86" />
-	<project path="packages/apps/Eleven" name="platform/packages/apps/Eleven" remote="x86" revision="q-x86" />
+	<!-- <project path="packages/apps/Eleven" name="platform/packages/apps/Eleven" remote="x86" revision="q-x86" /> -->
 	<project path="packages/apps/Gallery2" name="platform/packages/apps/Gallery2" remote="x86" revision="q-x86" />
 	<project path="packages/apps/Settings" name="packages_apps_Settings" remote="BR-x86" revision="q" />
 	<!-- <project path="packages/apps/Taskbar" name="platform/packages/apps/Taskbar" remote="x86" revision="q-x86" /> -->


### PR DESCRIPTION
ever since `platform_packages_apps_ThemePicker` commit `cc1ab4081d744ed0b0477f51829f7383b1002edc` build fails due to the commit are based on `android-10.0.0_r31`. Reverting to commit `155d480a2566c3f48a74c735bcb1652b61e92cf0` now fixes build issue

I don't know the purpose of `packages/apps/Eleven` in the first place and seeing `q10-x86` removes this package as well as Camera2 and Gallery2, it would be wise to disable `Eleven` source first due to dexopt error. Gallery2 and Camera2 passes dexopt so I left that unchanged for now 

fun fact I managed to build everything but since my target is `make rpm` it fails on making the rpm. figured that blissos once had rpm build so if you can point me to that commit I'd be happy to test and build rpm. maybe in the future include an option to build rpm in `build-x86.sh` script