### PR TITLE
Fix vendor-fdroid project name

### DIFF
--- a/foss.xml
+++ b/foss.xml
@@ -12,7 +12,7 @@
 <!--
 	<project name="vendor_fdroid" path="vendor/fdroid" remote="BR-x86" revision="pie" />
 -->
-	<project name="vendor_fdroid" path="vendor/fdroid" remote="bbpv" revision="p9.0-gms-testing" />
+	<project name="vendor-fdroid" path="vendor/fdroid" remote="bbpv" revision="p9.0-gms-testing" />
 		
 	<!--
 	<project name="lineageos4microg/android_prebuilts_prebuiltapks" path="vendor/fdroid" remote="github" revision="master" />


### PR DESCRIPTION
The `vendor-fdroid` project path is https://gitlab.com/Bliss-Bass/vendor-fdroid.