### PR TITLE
manifest: Use master branch for chromium-webview

### DIFF
--- a/los.xml
+++ b/los.xml
@@ -19,7 +19,7 @@
   <project path="external/ant-wireless/ant_native" name="android_external_ant-wireless_ant_native" remote="los" />
   <project path="external/ant-wireless/ant_service" name="android_external_ant-wireless_ant_service" remote="los" />
   <project path="external/ant-wireless/antradio-library" name="android_external_ant-wireless_antradio-library" remote="los" />
-  <project path="external/chromium-webview" name="android_external_chromium-webview" groups="pdk" clone-depth="1" remote="los" />
+  <project path="external/chromium-webview" name="android_external_chromium-webview" groups="pdk" revision="master" clone-depth="1" remote="los" />
   <project path="external/connectivity" name="android_external_connectivity" remote="los" />
   
   <project path="external/gptfdisk" name="android_external_gptfdisk" groups="pdk" remote="los" />


### PR DESCRIPTION
* The exact same prebuilt binaries are used across lineage releases,
  so let's eliminate the maintenance overhead of needing to pick
  updates across branches.

See
https://github.com/LineageOS/android/commit/7de0e02dd5ca87f85e0e537a1f685f5660019ac3.