### PR TITLE
[readme]Remove JDK-8 requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,6 @@ Please read the [AOSP building instructions](http://source.android.com/source/in
   
 -----------------------
 
-Installing Java 8
-
-    sudo add-apt-repository ppa:openjdk/ppa
-    sudo apt-get update && upgrade
-    sudo apt-get install openjdk-8-jdk
-    update-alternatives --config java  (make sure Java 8 is selected)
-    update-alternatives --config javac (make sure Java 8 is selected)
-    reboot
-    
------------------------
-
 ## Grabbing Dependencies
 
     sudo apt-get install git-core gnupg flex bison gperf build-essential zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386  lib32ncurses5-dev x11proto-core-dev libx11-dev lib32z-dev ccache libgl1-mesa-dev libxml2-utils xsltproc unzip squashfs-tools python3-mako libssl-dev ninja-build lunzip syslinux syslinux-utils gettext genisoimage gettext bc xorriso xmlstarlet meson glslang-tools git-lfs libncurses5 libncurses5:i386 libelf-dev


### PR DESCRIPTION
AOSP already uses prebuilt JDK in AOSP source tree, and it will be setup after source setup scripts.

cc @electrikjesus.